### PR TITLE
externalized SimulationType for simulation and reconstrucion, changed all neccessary scripts

### DIFF
--- a/python/create_sim_reco_pars.py
+++ b/python/create_sim_reco_pars.py
@@ -12,8 +12,9 @@ import cattrs
 from lumifit.alignment import AlignmentParameters
 from lumifit.experiment import ClusterEnvironment, Experiment, ExperimentType
 from lumifit.general import write_params_to_file
-from lumifit.reconstruction import ReconstructionParameters,ReconstructionType
+from lumifit.reconstruction import ReconstructionParameters
 from lumifit.simulation import SimulationParameters, generateDirectory
+from lumifit.simulationTypes import SimulationType
 
 # write_params_to_file(asdict(simpars), ".", "simparams.config")
 # write_params_to_file(asdict(recopars), ".", "recoparams.config")
@@ -27,7 +28,7 @@ def genExperimentConfig(
     phi_min: float,
     phi_max: float,
     experimentType: ExperimentType,
-    reconstructionType: ReconstructionType,
+    sim_type_for_resAcc: SimulationType,
 ) -> Experiment:
     simpars = SimulationParameters()
     recopars = ReconstructionParameters()
@@ -46,7 +47,7 @@ def genExperimentConfig(
     recopars.num_events_per_sample = 100000
     recopars.num_box_samples = 500
     recopars.num_events_per_box_sample = 100000
-    recopars.rec_type = reconstructionType
+    recopars.sim_type_for_resAcc = sim_type_for_resAcc
 
     lmdfit_data_dir = os.getenv("LMDFIT_DATA_DIR")
 
@@ -100,7 +101,7 @@ for mom in momenta:
         phi_min[0],
         phi_max[0],
         ExperimentType.LUMI,
-        ReconstructionType.BOX,
+        SimulationType.RESACCBOX,
     )
 
     write_params_to_file(
@@ -114,7 +115,7 @@ for mom in momenta:
         phi_min[1],
         phi_max[1],
         ExperimentType.KOALA,
-        ReconstructionType.PBARP_ELASTIC,
+        SimulationType.RESACCPBARP_ELASTIC,
     )
 
     write_params_to_file(

--- a/python/determineLuminosity.py
+++ b/python/determineLuminosity.py
@@ -25,11 +25,7 @@ from lumifit.reconstruction import (
     create_reconstruction_job,
 )
 from lumifit.scenario import Scenario
-from lumifit.simulation import (
-    SimulationParameters,
-#    SimulationType,
-    create_simulation_and_reconstruction_job,
-)
+from lumifit.simulation import create_simulation_and_reconstruction_job
 
 """
 This file needs one major rewrite, thats for sure.
@@ -228,9 +224,9 @@ def simulateDataOnHimster(
                     sim_par = thisExperiment.simParams
                     #! these mus be applied again, because they change at run time
                     # (the config on disk doesn't change and doesn't know this)
-                    sim_par.sim_type=rec_type
-                    sim_par.num_events_per_sample=box_num_events_per_sample
-                    sim_par.num_samples=box_num_samples
+                    sim_par.sim_type = sim_type_for_resAcc
+                    sim_par.num_events_per_sample = box_num_events_per_sample
+                    sim_par.num_samples = box_num_samples
                     sim_par.theta_min_in_mrad -= max_xy_shift
                     sim_par.theta_max_in_mrad += max_xy_shift
 
@@ -252,8 +248,8 @@ def simulateDataOnHimster(
 
                     #! these mus be applied again, because they can be overridden at command time
                     # (the config on disk doesn't change and doesn't know this)
-                    rec_par.num_events_per_sample=box_num_events_per_sample
-                    rec_par.num_samples=box_num_samples
+                    rec_par.num_events_per_sample = box_num_events_per_sample
+                    rec_par.num_samples = box_num_samples
                     rec_par.use_xy_cut = thisScenario.use_xy_cut
                     rec_par.use_m_cut = thisScenario.use_m_cut
 
@@ -878,7 +874,7 @@ bootstrapped_num_samples = args.bootstrapped_num_samples
 num_samples = experiment.recoParams.num_samples
 box_num_samples = experiment.recoParams.num_box_samples
 box_num_events_per_sample = experiment.recoParams.num_events_per_box_sample
-rec_type = experiment.recoParams.rec_type
+sim_type_for_resAcc = experiment.recoParams.sim_type_for_resAcc
 ipz = experiment.simParams.ip_offset_z
 
 # first lets try to find all directories and their status/step

--- a/python/lumifit/reconstruction.py
+++ b/python/lumifit/reconstruction.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 
-
 import errno
 import os
 from typing import Any, Tuple
-from enum import Enum
 
 import attr
 
 from .alignment import AlignmentParameters
 from .cluster import Job, JobResourceRequest, make_test_job_resource_request
 from .general import write_params_to_file
+from .simulationTypes import SimulationType
 
 # TODO: solve the track_search_algorithms with Enum (or IntEnum for json serializability)
 #! wait there is even an enumEncoder, IntEnums may not be neccessary
@@ -19,9 +18,10 @@ track_search_algorithms = ["CA", "Follow"]
 
 lmdScriptPath = os.environ["LMDFIT_SCRIPTPATH"]
 
-class ReconstructionType(Enum):
-    BOX = "box"
-    PBARP_ELASTIC = "dpm_elastic"
+# class ReconstructionType(Enum):
+#     BOX = "box"
+#     PBARP_ELASTIC = "dpm_elastic"
+
 
 @attr.s
 class ReconstructionParameters:
@@ -29,7 +29,7 @@ class ReconstructionParameters:
         if value not in track_search_algorithms:
             raise ValueError(f"Must be either of {track_search_algorithms}.")
 
-    rec_type: ReconstructionType = attr.ib(default=ReconstructionType.BOX)
+    sim_type_for_resAcc: SimulationType = attr.ib(default=SimulationType.BOX)
     num_events_per_sample: int = attr.ib(default=1000)
     num_samples: int = attr.ib(default=1)
     lab_momentum: float = attr.ib(default=1.5)

--- a/python/lumifit/simulation.py
+++ b/python/lumifit/simulation.py
@@ -1,8 +1,9 @@
+#!/usr/bin/env python3
+
 import math
 import os
 import random
 import subprocess
-from enum import Enum
 from typing import Any, Tuple
 
 import attr
@@ -12,15 +13,9 @@ from .alignment import AlignmentParameters
 from .cluster import Job, JobResourceRequest, make_test_job_resource_request
 from .general import write_params_to_file
 from .reconstruction import ReconstructionParameters, generateRecoDirSuffix
+from .simulationTypes import SimulationType
 
 load_dotenv(dotenv_path="../lmdEnvFile.env", verbose=True)
-
-
-class SimulationType(Enum):
-    BOX = "box"
-    PBARP_ELASTIC = "dpm_elastic"
-    PBARP = "dpm_elastic_inelastic"
-    NOISE = "noise"
 
 
 @attr.s
@@ -101,7 +96,7 @@ def generateDirectory(
         dirname += "/" + gen_part
 
         # if not _check_ip_params_zero(sim_params):
-        #* always write that
+        # * always write that
         dirname += (
             "/ip_offset_XYZDXDYDZ_"
             + f"{sim_params.ip_offset_x}_{sim_params.ip_offset_y}_"
@@ -109,7 +104,7 @@ def generateDirectory(
             + f"{sim_params.ip_spread_y}_{sim_params.ip_spread_z}"
         )
 
-        #* always write that
+        # * always write that
         # if not _check_beam_params_zero(sim_params):
         dirname += (
             "/beam_grad_XYDXDY_"

--- a/python/lumifit/simulationTypes.py
+++ b/python/lumifit/simulationTypes.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class SimulationType(Enum):
+    BOX = "box"
+    PBARP_ELASTIC = "dpm_elastic"
+    PBARP = "dpm_elastic_inelastic"
+    NOISE = "noise"
+    RESACCBOX = "resAcc-box"
+    RESACCPBARP_ELASTIC = "resAcc-dpm_elastic"

--- a/python/runKoaSimReco.py
+++ b/python/runKoaSimReco.py
@@ -3,9 +3,9 @@
 import os
 
 from lumifit.alignment import AlignmentParameters
-from lumifit.general import check_stage_success, load_params_from_file
-from lumifit.simulation import SimulationParameters, SimulationType
-from lumifit.general import toCbool
+from lumifit.general import check_stage_success, load_params_from_file, toCbool
+from lumifit.simulation import SimulationParameters
+from lumifit.simulationTypes import SimulationType
 
 lmd_build_path = os.environ["LMDFIT_BUILD_PATH"]
 scriptpath = os.environ["LMDFIT_SCRIPTPATH"]
@@ -49,7 +49,10 @@ if (
     or force_level == 2
 ):
     os.chdir(scriptpath)
-    if sim_params.sim_type == SimulationType.BOX:
+    if (
+        sim_params.sim_type == SimulationType.BOX
+        or sim_params.sim_type == SimulationType.RESACCBOX
+    ):
         os.system(
             f"{lmd_build_path}/bin/generatePbarPElasticScattering"
             + f" {sim_params.lab_momentum} {sim_params.num_events_per_sample}"
@@ -60,7 +63,10 @@ if (
             + f" -o {gen_filepath}"
         )
 
-    elif sim_params.sim_type == SimulationType.PBARP_ELASTIC:
+    elif (
+        sim_params.sim_type == SimulationType.PBARP_ELASTIC
+        or sim_params.sim_type == SimulationType.RESACCPBARP_ELASTIC
+    ):
         os.system(
             f"{lmd_build_path}/bin/generatePbarPElasticScattering"
             + f" {sim_params.lab_momentum} {sim_params.num_events_per_sample}"

--- a/python/runLmdSimReco.py
+++ b/python/runLmdSimReco.py
@@ -4,7 +4,8 @@ import os
 
 from lumifit.alignment import AlignmentParameters
 from lumifit.general import check_stage_success, load_params_from_file
-from lumifit.simulation import SimulationParameters, SimulationType
+from lumifit.simulation import SimulationParameters
+from lumifit.simulationTypes import SimulationType
 
 lmd_build_path = os.environ["LMDFIT_BUILD_PATH"]
 PNDmacropath = os.environ["LMDFIT_MACROPATH"]
@@ -86,7 +87,10 @@ if (
 ):
 
     # * prepare box or dpm tracks
-    if sim_params.sim_type == SimulationType.BOX:
+    if (
+        sim_params.sim_type == SimulationType.BOX
+        or sim_params.sim_type == SimulationType.RESACCBOX
+    ):
         os.chdir(LMDscriptpath)
 
         cmd = f"""root -l -b -q 'standaloneBoxGen.C({sim_params.lab_momentum}, {sim_params.num_events_per_sample}, {sim_params.theta_min_in_mrad}, {sim_params.theta_max_in_mrad}, {sim_params.phi_min_in_rad}, {sim_params.phi_max_in_rad},"{gen_filepath}", {sim_params.random_seed + start_evt}, {int(not sim_params.neglect_recoil_momentum)})'"""
@@ -95,7 +99,10 @@ if (
         print(cmd)
         os.system(cmd)
 
-    elif sim_params.sim_type == SimulationType.PBARP_ELASTIC:
+    elif (
+        sim_params.sim_type == SimulationType.PBARP_ELASTIC
+        or sim_params.sim_type == SimulationType.RESACCPBARP_ELASTIC
+    ):
 
         cmd = f"{lmd_build_path}/bin/generatePbarPElasticScattering {sim_params.lab_momentum} {sim_params.num_events_per_sample} -l {sim_params.theta_min_in_mrad} -u {sim_params.theta_max_in_mrad} -s {sim_params.random_seed + start_evt} -o {gen_filepath}"
 


### PR DESCRIPTION
This was needed so that the folders for the res/acc data get distict names. I still want them to include either "box" or "dpm_elastic" (and I think some scripts even rely on that), but they get a prefix "resAcc-" now.

This should also fix the issue in the KOALA part where sometimes the dpm folder wasn't found.