### PR TITLE
updated docker image to use new fairroot:miniNov22p1

### DIFF
--- a/docker/Dockerfile-Nov22p1
+++ b/docker/Dockerfile-Nov22p1
@@ -1,0 +1,16 @@
+from rklasen/fairroot:miniNov22p1
+
+ARG USERNAME=pandauser
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# we're inherting from faoroot, in which we are UID 1000
+USER root
+
+COPY requirements.txt docker/rc.append /tmp/
+
+RUN pip3 install --break-system-packages --no-cache-dir -r /tmp/requirements.txt \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 2 \
+    && cat /tmp/rc.append >> /mnt/work/.bashrc
+
+USER $USERNAME


### PR DESCRIPTION
The new fairroot mini image uses debian 12 and the most recent fairroot version, which is Nov22p1.

As soon as the Lumifit software compiles in the container, I'll merge the PR.